### PR TITLE
[XBEAN-278, XBEAN-279] Fix problems with Blueprint XBeanNamespaceHandler...

### DIFF
--- a/xbean-blueprint/pom.xml
+++ b/xbean-blueprint/pom.xml
@@ -40,18 +40,17 @@
 
     </properties>
     <dependencies>
-
-        <dependency>
-            <groupId>org.apache.aries.blueprint</groupId>
-            <artifactId>org.apache.aries.blueprint.api</artifactId>
-            <version>1.0.0</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.aries.blueprint</groupId>
             <artifactId>org.apache.aries.blueprint.cm</artifactId>
             <version>1.0.0</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.aries.blueprint</groupId>
+                    <artifactId>org.apache.aries.blueprint.core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -118,6 +117,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+        	<groupId>org.apache.aries.blueprint</groupId>
+        	<artifactId>org.apache.aries.blueprint.noosgi</artifactId>
+        	<version>1.1.0-SNAPSHOT</version>
+        	<scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -187,6 +192,41 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.apache.maven.plugins
+        								</groupId>
+        								<artifactId>
+        									maven-antrun-plugin
+        								</artifactId>
+        								<versionRange>
+        									[1.6,)
+        								</versionRange>
+        								<goals>
+        									<goal>run</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/BeerUsingBlueprintTest.java
+++ b/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/BeerUsingBlueprintTest.java
@@ -16,8 +16,7 @@
  */
 package org.apache.xbean.blueprint.context;
 
-import org.apache.aries.blueprint.ComponentDefinitionRegistry;
-import org.apache.aries.blueprint.reflect.BeanMetadataImpl;
+import org.apache.xbean.blueprint.example.BeerService;
 
 /**
  * @author James Strachan
@@ -27,10 +26,10 @@ import org.apache.aries.blueprint.reflect.BeanMetadataImpl;
 public class BeerUsingBlueprintTest extends BlueprintTestSupport {
     
     public void testBeer() throws Exception {
-        BeanMetadataImpl meta = (BeanMetadataImpl) reg.getComponentDefinition("beerService");
-        checkPropertyValue("name", "Stella", meta);
-        checkPropertyValue("id", "123", meta);
-        assertEquals("id", "beerService", meta.getId());
+        BeerService o = (BeerService)container.getComponentInstance("beerService");
+        assertNotNull(o);
+        assertEquals("name", "Stella", o.getName());
+        assertEquals("id", "123", o.getId());
     }
 
     protected String getPlan() {

--- a/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/ComponentTest.java
+++ b/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/ComponentTest.java
@@ -39,7 +39,7 @@ public class ComponentTest extends TestCase {
     }
     
     protected void test(String file) throws Exception {
-        ComponentDefinitionRegistry f = BlueprintTestSupport.parse(file);
+        ComponentDefinitionRegistry f = BlueprintTestSupport.parse(file).getComponentDefinitionRegistry();
         BeanMetadataImpl meta = (BeanMetadataImpl) f.getComponentDefinition("container");
         assertNotNull(meta);
         CollectionMetadata list = (CollectionMetadata) BlueprintTestSupport.propertyByName("beans", meta).getValue();

--- a/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/KegXBeanTest.java
+++ b/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/KegXBeanTest.java
@@ -29,20 +29,22 @@ import org.apache.aries.blueprint.reflect.BeanMetadataImpl;
 public class KegXBeanTest extends BlueprintTestSupport {
 
     public void testBeer() throws Exception {
-        //TODO blueprint value conversion using units??
-        BeanMetadataImpl ml1000 = (BeanMetadataImpl) reg.getComponentDefinition("ml1000");
-        BeanMetadataImpl empty = (BeanMetadataImpl) reg.getComponentDefinition("empty");
-        BeanMetadataImpl pints5 = (BeanMetadataImpl) reg.getComponentDefinition("pints5");
-        BeanMetadataImpl liter20 = (BeanMetadataImpl) reg.getComponentDefinition("liter20");
         
-        checkPropertyValue("remaining", "1000", ml1000);
-        checkPropertyValue("remaining", "0", empty);
-        checkPropertyValue("remaining", "8750", pints5);
-        checkPropertyValue("remaining", "20000", liter20);
-//        checkPropertyValue("remaining", "1000", ml1000);
-//        checkPropertyValue("remaining", "0", empty);
-//        checkPropertyValue("remaining", "8750", pints5);
-//        checkPropertyValue("remaining", "20000", liter20);
+        KegService keg = (KegService)container.getComponentInstance("ml1000");
+        assertNotNull(keg);
+        assertEquals(1000, keg.getRemaining());
+        
+        keg = (KegService)container.getComponentInstance("empty");
+        assertNotNull(keg);
+        assertEquals(0, keg.getRemaining());
+
+        keg = (KegService)container.getComponentInstance("pints5");
+        assertNotNull(keg);
+        assertEquals(8750, keg.getRemaining());
+
+        keg = (KegService)container.getComponentInstance("liter20");
+        assertNotNull(keg);
+        assertEquals(20000, keg.getRemaining());
 
     }
 

--- a/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/SoupUsingXBeanTest.java
+++ b/xbean-blueprint/src/test/java/org/apache/xbean/blueprint/context/SoupUsingXBeanTest.java
@@ -23,11 +23,9 @@ package org.apache.xbean.blueprint.context;
  */
 public class SoupUsingXBeanTest extends SoupUsingBlueprintTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        reg = parse(getPlan(), "META-INF/services/org/apache/xbean/blueprint/http/xbean.apache.org/schemas/soup");
+    protected String getSchema() {
+        return "META-INF/services/org/apache/xbean/blueprint/http/xbean.apache.org/schemas/soup";
     }
-
     protected String getPlan() {
         return "org/apache/xbean/blueprint/context/soup-xbean.xml";
     }

--- a/xbean-blueprint/src/test/resources/org/apache/xbean/blueprint/context/beer-xbean-ns.xml
+++ b/xbean-blueprint/src/test/resources/org/apache/xbean/blueprint/context/beer-xbean-ns.xml
@@ -22,7 +22,7 @@
        xmlns:s="http://www.osgi.org/xmlns/blueprint/v1.0.0"
        xmlns="http://xbean.apache.org/schemas/pizza">
 
-  <beer b:id="123" id="beerService" name="Stella"/>
+  <beer b:id="123" s:id="beerService" name="Stella"/>
 
 </s:blueprint>
 <!-- END SNIPPET: xml -->

--- a/xbean-blueprint/src/test/resources/org/apache/xbean/blueprint/context/soup-xbean.xml
+++ b/xbean-blueprint/src/test/resources/org/apache/xbean/blueprint/context/soup-xbean.xml
@@ -20,9 +20,9 @@
 <!-- START SNIPPET: xml -->
 <b:blueprint xmlns:b="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:s="http://xbean.apache.org/schemas/pizza">
 
-  <s:soup b:id="soupService" s:id="soupService" s:type="French Onion"/>
+  <s:soup b:id="soupService" s:type="French Onion"/>
 
-  <s:soup b:id="nestedBean" s:id="nestedBean">
+  <s:soup b:id="nestedBean" >
     <s:type>
       <b:bean class="java.lang.String">
         <b:argument index="0" value="French Onion"/>
@@ -30,7 +30,7 @@
     </s:type>
   </s:soup>
 
-  <s:soup b:id="nestedValue" s:id="nestedValue">
+  <s:soup b:id="nestedValue">
     <s:type>
       <b:value>French Onion</b:value>
     </s:type>


### PR DESCRIPTION
... related to flat collections and PropertyEditors

Couple of notes:
1) This has a dependency on a snapshot version of blueprint-noosgi.   I'll work on a release of that very shortly.

2) The reason for blueprint-noosgi is to actually have blueprint create instances of some of the beans to make sure that not only are they parsed correctly, the resulting blueprint container can create the beans.
