### PR TITLE
EmptyVisitor used in AsmParameterNameLoader may cause a ClassNotFoundException

### DIFF
--- a/xbean-reflect/pom.xml
+++ b/xbean-reflect/pom.xml
@@ -47,12 +47,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>org.apache.xbean</groupId>
-          <artifactId>xbean-asm-util</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-asm5-shaded</artifactId>
             <version>${project.version}</version>

--- a/xbean-reflect/src/main/java/org/apache/xbean/recipe/AsmParameterNameLoader.java
+++ b/xbean-reflect/src/main/java/org/apache/xbean/recipe/AsmParameterNameLoader.java
@@ -17,8 +17,8 @@
  */
 package org.apache.xbean.recipe;
 
-import org.apache.xbean.asm5.original.commons.EmptyVisitor;
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -211,7 +211,7 @@ public class AsmParameterNameLoader implements ParameterNameLoader {
         }
     }
 
-    private static class AllParameterNamesDiscoveringVisitor extends EmptyVisitor {
+    private static class AllParameterNamesDiscoveringVisitor extends ClassVisitor {
         private final Map<Constructor,List<String>> constructorParameters = new HashMap<Constructor,List<String>>();
         private final Map<Method,List<String>> methodParameters = new HashMap<Method,List<String>>();
         private final Map<String,Exception> exceptions = new HashMap<String,Exception>();
@@ -220,6 +220,7 @@ public class AsmParameterNameLoader implements ParameterNameLoader {
         private final Map<String,Constructor> constructorMap = new HashMap<String,Constructor>();
 
         public AllParameterNamesDiscoveringVisitor(Class type, String methodName) {
+            super(Opcodes.ASM5);
             this.methodName = methodName;
 
             List<Method> methods = new ArrayList<Method>(Arrays.asList(type.getMethods()));
@@ -232,6 +233,7 @@ public class AsmParameterNameLoader implements ParameterNameLoader {
         }
 
         public AllParameterNamesDiscoveringVisitor(Class type) {
+            super(Opcodes.ASM5);
             this.methodName = "<init>";
 
             List<Constructor> constructors = new ArrayList<Constructor>(Arrays.asList(type.getConstructors()));

--- a/xbean-reflect/src/test/java/org/apache/xbean/recipe/AsmParameterNameLoaderTest.java
+++ b/xbean-reflect/src/test/java/org/apache/xbean/recipe/AsmParameterNameLoaderTest.java
@@ -1,0 +1,50 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.xbean.recipe;
+
+public class AsmParameterNameLoaderTest extends ParameterNameLoaderTest {
+
+    protected void setUp() throws Exception {
+        parameterNameLoader = new AsmParameterNameLoader();
+    }
+
+    @Override
+    public void testMethodAnnotated() throws Exception {
+        // AsmParameterNameLoader doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testStaticMethodAnnotated() throws Exception {
+        // AsmParameterNameLoader doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testInheritedMethodAnnotated() throws Exception {
+        // AsmParameterNameLoader doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testPrivateConstructorAnnotated() throws Exception {
+        // AsmParameterNameLoader doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testPrivateMethodAnnotated() throws Exception {
+        // AsmParameterNameLoader doesn't handle annotated parameters
+    }
+}

--- a/xbean-reflect/src/test/java/org/apache/xbean/recipe/ParameterNameLoaderTest.java
+++ b/xbean-reflect/src/test/java/org/apache/xbean/recipe/ParameterNameLoaderTest.java
@@ -30,6 +30,17 @@ import junit.framework.TestCase;
  * @version $Rev$ $Date$
  */
 public class ParameterNameLoaderTest extends TestCase {
+
+    protected ParameterNameLoader parameterNameLoader = new ParameterNameLoader() {
+        public List<String> get(Method method) {
+            return ReflectionUtil.getParameterNames(method);
+        }
+
+        public List<String> get(Constructor constructor) {
+            return ReflectionUtil.getParameterNames(constructor);
+        }
+    };
+
     public void testConstructor() throws Exception {
         Constructor constructor = TestClass.class.getConstructor(int.class, Object.class, Long.class);
         assertParameterNames(Arrays.asList("one", "two", "three"), constructor);
@@ -166,12 +177,12 @@ public class ParameterNameLoaderTest extends TestCase {
     }
 
     private void assertParameterNames(List<String> expectedNames, Constructor constructor) {
-        List<String> actualNames = ReflectionUtil.getParameterNames(constructor);
+        List<String> actualNames = parameterNameLoader.get(constructor);
         assertEquals(expectedNames, actualNames);
     }
 
     private void assertParameterNames(List<String> expectedNames, Method method) {
-        List<String> actualNames = ReflectionUtil.getParameterNames(method);
+        List<String> actualNames = parameterNameLoader.get(method);
         assertEquals(expectedNames, actualNames);
     }
 

--- a/xbean-reflect/src/test/java/org/apache/xbean/recipe/ParameterNameLoaderTest.java
+++ b/xbean-reflect/src/test/java/org/apache/xbean/recipe/ParameterNameLoaderTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -101,6 +102,11 @@ public class ParameterNameLoaderTest extends TestCase {
         assertParameterNames(Arrays.asList("shot"), method);
     }
 
+    public void testEmptyMethod() throws Exception {
+        Method method = TestClass.class.getMethod("emptyMethod");
+        assertParameterNames(Collections.<String>emptyList(), method);
+    }
+
     @SuppressWarnings({"UnusedDeclaration"})
     private static class ParentTestClass {
         public void inheritedMethod(Map nothing) {}
@@ -128,6 +134,8 @@ public class ParameterNameLoaderTest extends TestCase {
         public void mixedMethods(Short tonic) {}
 
         public abstract void abstractMethod(Byte ear);
+        
+        public void emptyMethod() {}
     }
 
     @SuppressWarnings({"UnusedDeclaration"})

--- a/xbean-reflect/src/test/java/org/apache/xbean/recipe/XbeanAsmParameterNameLoaderTest.java
+++ b/xbean-reflect/src/test/java/org/apache/xbean/recipe/XbeanAsmParameterNameLoaderTest.java
@@ -1,0 +1,51 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.xbean.recipe;
+
+public class XbeanAsmParameterNameLoaderTest extends ParameterNameLoaderTest {
+    
+    protected void setUp() throws Exception {
+        parameterNameLoader = new XbeanAsmParameterNameLoader();
+    }
+    
+    @Override
+    public void testMethodAnnotated() throws Exception {
+        // XbeanAsmParameterNameLoaderTest doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testStaticMethodAnnotated() throws Exception {
+        // XbeanAsmParameterNameLoaderTest doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testInheritedMethodAnnotated() throws Exception {
+        // XbeanAsmParameterNameLoaderTest doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testPrivateConstructorAnnotated() throws Exception {
+        // XbeanAsmParameterNameLoaderTest doesn't handle annotated parameters
+    }
+
+    @Override
+    public void testPrivateMethodAnnotated() throws Exception {
+        // XbeanAsmParameterNameLoaderTest doesn't handle annotated parameters
+    }
+}


### PR DESCRIPTION
Hi,

We've been hit by an exception when building wagon in Debian with xbean 4.3. The unit tests for wagon-file failed with this exception:

```
java.lang.ClassNotFoundException: org.apache.xbean.asm5.original.commons.EmptyVisitor
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:760)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.apache.xbean.recipe.ReflectionUtil.<clinit>(ReflectionUtil.java:47)
        at org.apache.xbean.recipe.ObjectRecipe.findFactory(ObjectRecipe.java:563)
        at org.apache.xbean.recipe.ObjectRecipe.internalCreate(ObjectRecipe.java:274)
        at org.apache.xbean.recipe.AbstractRecipe.create(AbstractRecipe.java:96)
        at org.apache.xbean.recipe.AbstractRecipe.create(AbstractRecipe.java:61)
        at org.apache.xbean.recipe.AbstractRecipe.create(AbstractRecipe.java:49)
        at org.codehaus.plexus.component.builder.XBeanComponentBuilder.createComponentInstance(XBeanComponentBuilder.java:158)
        at org.codehaus.plexus.component.builder.XBeanComponentBuilder.build(XBeanComponentBuilder.java:123)
        at org.codehaus.plexus.component.manager.AbstractComponentManager.createComponentInstance(AbstractComponentManager.java:181)
        at org.codehaus.plexus.component.manager.PerLookupComponentManager.getComponent(PerLookupComponentManager.java:51)
        at org.codehaus.plexus.DefaultComponentRegistry.getComponent(DefaultComponentRegistry.java:327)
        at org.codehaus.plexus.DefaultComponentRegistry.lookup(DefaultComponentRegistry.java:163)
        at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:373)
        at org.codehaus.plexus.PlexusTestCase.lookup(PlexusTestCase.java:204)
        at org.apache.maven.wagon.WagonTestCase.getWagon(WagonTestCase.java:209)
        at org.apache.maven.wagon.StreamingWagonTestCase.testFailedGetToStream(StreamingWagonTestCase.java:64)
```

We can see that the static initializer in `ReflectionUtil` instantiates `AsmParameterNameLoader` at line 47. This statement is reached after checking at line 44 that `org.apache.xbean.asm5.ClassReader` is not available (as well as all the classes from xbean-asm5-shaded if I'm not mistaken). But `AsmParameterNameLoader` uses the `EmptyVisitor` from xbean-asm5-shaded for its `AllParameterNamesDiscoveringVisitor`, and this triggers the `ClassNotFoundException` because the class is not available.

I replaced the `EmptyVisitor` with the `ClassVisitor` from ASM in `AsmParameterNameLoader` and it seems to work.
