### PR TITLE
xbean-telnet compatibility with Groovy 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,9 +265,9 @@
             </dependency>
 
             <dependency>
-                <groupId>groovy</groupId>
-                <artifactId>groovy</artifactId>
-                <version>1.0-jsr-03</version>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>2.2.0</version>
             </dependency>
 
             <dependency>

--- a/xbean-telnet/pom.xml
+++ b/xbean-telnet/pom.xml
@@ -36,8 +36,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>groovy</groupId>
-            <artifactId>groovy</artifactId>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
         </dependency>
 
     </dependencies>

--- a/xbean-telnet/src/main/java/org/apache/xbean/command/GroovySh.java
+++ b/xbean-telnet/src/main/java/org/apache/xbean/command/GroovySh.java
@@ -17,6 +17,7 @@
 package org.apache.xbean.command;
 
 import groovy.lang.GroovyShell;
+import groovy.lang.GroovySystem;
 import org.codehaus.groovy.runtime.InvokerHelper;
 
 import java.io.BufferedReader;
@@ -33,7 +34,7 @@ public class GroovySh implements Command {
     public int main(String[] args, InputStream in, PrintStream out) {
         GroovyShell shell = new GroovyShell();
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-        String version = InvokerHelper.getVersion();
+        String version = GroovySystem.getVersion();
         out.println("Lets get Groovy!");
         out.println("================");
         out.println("Version: " + version + " JVM: " + System.getProperty("java.vm.version"));


### PR DESCRIPTION
The `GroovySh` class in xbean-telnet uses the `InvokerHelper.getVersion()` method which was deprecated in Groovy 1.7 and removed in Groovy 2.0. I replaced it with `GroovySystem.getVersion()` which is available since Groovy 1.6.
