### PR TITLE
[XBEAN-340] Fix test failed of `JarArchiveTest#testXBEAN337`

### DIFF
--- a/xbean-finder/src/test/java/org/apache/xbean/finder/archive/JarArchiveTest.java
+++ b/xbean-finder/src/test/java/org/apache/xbean/finder/archive/JarArchiveTest.java
@@ -160,7 +160,7 @@ public class JarArchiveTest {
             Assert.fail(String.format("Muzz eat only local file URLs:"
                     + " 'file:/...' or 'jar:file:/...!/' but not '%s'",
                     urls[0]));
-        }catch(UnsupportedOperationException ex){
+        }catch(IllegalArgumentException ex){
 
         }
     }

--- a/xbean-finder/src/test/java/org/apache/xbean/finder/archive/JarArchiveTest.java
+++ b/xbean-finder/src/test/java/org/apache/xbean/finder/archive/JarArchiveTest.java
@@ -160,7 +160,7 @@ public class JarArchiveTest {
             Assert.fail(String.format("Muzz eat only local file URLs:"
                     + " 'file:/...' or 'jar:file:/...!/' but not '%s'",
                     urls[0]));
-        }catch(IllegalArgumentException ex){
+        } catch (UnsupportedOperationException | IllegalArgumentException ex) {
 
         }
     }


### PR DESCRIPTION
Run `mvn clean install` in the following environment:

1. MacOS 13.2.1, open jdk 1.8.0_362, maven 3.8.7
2. CentOS 6.3, open jdk 1.8.0_352, maven 3.8.6

`JarArchiveTest#testXBEAN337` will be test failed as follows:

```
[ERROR] Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.039 s <<< FAILURE! - in org.apache.xbean.finder.archive.JarArchiveTest
[ERROR] testXBEAN337(org.apache.xbean.finder.archive.JarArchiveTest)  Time elapsed: 0.005 s  <<< ERROR!
java.lang.IllegalArgumentException: Please provide 'file:/...' or 'jar:file:/...!/' URL instead of 'http:ftp:jar:file:/tmp/junit8712324922078383147/!JarArchiveTest!-temp!/path with spaces4573946630928385333.jar!/'
        at org.apache.xbean.finder.archive.JarArchiveTest.testXBEAN337(JarArchiveTest.java:159)
[ERROR] Errors: 
[ERROR]   JarArchiveTest.testXBEAN337:159  IllegalArgument Please provide 'file:/...' o...
[INFO] 
[ERROR] Tests run: 111, Failures: 0, Errors: 1, Skipped: 2 
```

https://github.com/apache/geronimo-xbean/blob/e40b760ffe7e36a50c5a524395e84fffc46f07aa/xbean-finder/src/test/java/org/apache/xbean/finder/archive/JarArchiveTest.java#L163

may also need catch `IllegalArgumentException` thrown by 

https://github.com/apache/geronimo-xbean/blob/e40b760ffe7e36a50c5a524395e84fffc46f07aa/xbean-finder/src/main/java/org/apache/xbean/finder/archive/JarArchive.java#L94-L96


So this pr add catch for `IllegalArgumentException`  and  after this change `mvn clean install` can run successfully in above test environments.


