### PR TITLE
[XBEAN-341] Upgrade ASM from 9.5 to 9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <asm.version>9.5</asm.version>
+        <asm.version>9.6</asm.version>
         <spring.version>5.3.18</spring.version>
 
         <xbean.automatic.module.name>${project.groupId}</xbean.automatic.module.name>


### PR DESCRIPTION
This pr aims to upgrade ASM from 9.5 to 9.6, the new version is for Java 22.

