### PR TITLE
[XBEAN-347] Upgrade ASM from 9.7 to 9.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <asm.version>9.7</asm.version>
+        <asm.version>9.7.1</asm.version>
         <spring.version>5.3.18</spring.version>
 
         <xbean.automatic.module.name>${project.groupId}</xbean.automatic.module.name>


### PR DESCRIPTION
The pr aims to upgrade `ASM` from `9.7` to `9.7.1`, the new version is for Java 24.