### PR TITLE
XBEAN-354 revision - fix build on jdk 8

### DIFF
--- a/xbean-reflect/src/test/java/org/apache/xbean/recipe/XBean354Test.java
+++ b/xbean-reflect/src/test/java/org/apache/xbean/recipe/XBean354Test.java
@@ -24,11 +24,15 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
 
 
 public class XBean354Test {
     @Test
     public void testRecipeBootstrapClass() {
+        // broken on java 1.8 because openjdk seems to have been compiled without parameter names for constructors
+        assumeFalse("JDK not 1.8", System.getProperty("java.version").startsWith("1.8"));
+
         ObjectRecipe recipe = new ObjectRecipe(URL.class);
         recipe.setConstructorArgNames(Collections.singletonList("spec"));
         recipe.setAllProperties(Collections.singletonMap("spec", "https://apache.org"));


### PR DESCRIPTION
See output of `javap -v java.net.URL` for JDK 1.8:
```
  public java.net.URL(java.lang.String) throws java.net.MalformedURLException;
    descriptor: (Ljava/lang/String;)V
    flags: ACC_PUBLIC
    Code:
      stack=3, locals=2, args_size=2
         0: aload_0
         1: aconst_null
         2: aload_1
         3: invokespecial #44                 // Method "<init>":(Ljava/net/URL;Ljava/lang/String;)V
         6: return
      LineNumberTable:
        line 457: 0
        line 458: 6
    Exceptions:
      throws java.net.MalformedURLException
```

vs JDK 9:
```
  public java.net.URL(java.lang.String) throws java.net.MalformedURLException;
    descriptor: (Ljava/lang/String;)V
    flags: (0x0001) ACC_PUBLIC
    Code:
      stack=3, locals=2, args_size=2
         0: aload_0
         1: aconst_null
         2: aload_1
         3: invokespecial #38                 // Method "<init>":(Ljava/net/URL;Ljava/lang/String;)V
         6: return
      LineNumberTable:
        line 468: 0
        line 469: 6
      LocalVariableTable:
        Start  Length  Slot  Name   Signature
            0       7     0  this   Ljava/net/URL;
            0       7     1  spec   Ljava/lang/String;
    Exceptions:
      throws java.net.MalformedURLException
```

running this test on jdk 1.8 is broken and makes no sense